### PR TITLE
Config.in: Enable automatic selection of CA Certificates

### DIFF
--- a/package/shellhub/Config.in
+++ b/package/shellhub/Config.in
@@ -3,6 +3,7 @@ config BR2_PACKAGE_SHELLHUB
         depends on BR2_PACKAGE_HOST_GO_TARGET_ARCH_SUPPORTS
         depends on BR2_PACKAGE_HOST_GO_TARGET_CGO_LINKING_SUPPORTS
         depends on BR2_TOOLCHAIN_HAS_THREADS
+	select BR2_PACKAGE_CA_CERTIFICATES
 	select BR2_PACKAGE_LIBXCRYPT
 	help
           Get seamless remote access to any Linux device.


### PR DESCRIPTION
This change addresses a dependency issue where the CA Certificates package was required for proper operation but was not enabled by default, causing runtime errors during TLS verification.