### PR TITLE
fix: use Makefile syntax for version variable in LDFLAGS

### DIFF
--- a/package/shellhub/shellhub.mk
+++ b/package/shellhub/shellhub.mk
@@ -7,7 +7,7 @@ SHELLHUB_DEPENDENCIES = \
 	libxcrypt \
 	ca-certificates
 SHELLHUB_GOMOD = github.com/shellhub-io/shellhub/agent
-SHELLHUB_LDFLAGS = -X main.AgentVersion=v${SHELLHUB_VERSION}
+SHELLHUB_LDFLAGS = -X main.AgentVersion=v$(SHELLHUB_VERSION)
 
 define SHELLHUB_INSTALL_INIT_SYSTEMD
         $(INSTALL) -D -m 0644 $(SHELLHUB_PKGDIR)/shellhub.service \


### PR DESCRIPTION
## Summary

- Use `$(SHELLHUB_VERSION)` instead of `${SHELLHUB_VERSION}` in LDFLAGS for consistency with Buildroot Makefile conventions

## Test plan

- [ ] CI pipeline triggers `build-and-test` (no `update-hash` or `auto-merge` since this is not a Renovate PR)
- [ ] Buildroot builds successfully with the external toolchain
- [ ] QEMU tests pass (binary exists, version works, init script installed)