### PR TITLE
chore: migrate Renovate config syntax

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,8 @@
 {
-  "extends": ["config:base"],
-  "regexManagers": [
+  "extends": ["config:recommended"],
+  "customManagers": [
     {
+      "customType": "regex",
       "fileMatch": ["^package/shellhub/shellhub\\.mk$"],
       "matchStrings": [
         "SHELLHUB_VERSION = (?<currentValue>\\d+\\.\\d+\\.\\d+)"
@@ -13,13 +14,13 @@
   ],
   "packageRules": [
     {
-      "matchPackagePatterns": [
+      "matchPackageNames": [
         "*"
       ],
       "enabled": false
     },
     {
-      "matchPackagePatterns": [
+      "matchPackageNames": [
         "shellhub-io/shellhub"
       ],
       "enabled": true


### PR DESCRIPTION
## Summary
- migrates Renovate from deprecated `config:base` to `config:recommended`
- converts `regexManagers` to `customManagers` with `customType: "regex"`
- updates `matchPackagePatterns` to `matchPackageNames` while preserving the existing ShellHub allow-list behavior

## Context
Dependency Dashboard #4 currently shows `Config Migration Needed`; this keeps the current ShellHub tag tracking intent intact while applying Renovate's current config syntax.

## Test plan
- `python3 -m json.tool .github/renovate.json`
- `git diff --check`
