### PR TITLE
ci: bump Buildroot to 2026.02.2 for Go 1.25.8+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Clone Buildroot
         run: |
-          git clone --depth 1 --branch 2026.02 https://github.com/buildroot/buildroot.git /tmp/buildroot
+          git clone --depth 1 --branch 2026.02.2 https://github.com/buildroot/buildroot.git /tmp/buildroot
 
       - name: Cache Buildroot downloads
         uses: actions/cache@v4


### PR DESCRIPTION
## What

Pin the Buildroot checkout in CI from tag `2026.02` to the point release `2026.02.2`.

## Why

Buildroot `2026.02` ships Go 1.25.7, but the agent's `go.mod` requires Go >= 1.25.8. CI builds the agent offline (`GOTOOLCHAIN=local`, `GOPROXY=off`), so the toolchain can't self-upgrade and the build hard-fails:

```
go: go.mod requires go >= 1.25.8 (running go 1.25.7; GOTOOLCHAIN=local)
```

The `2026.02.2` point release ships Go 1.26.3, satisfying the requirement. Point releases stay on the same stable series (bugfix + package bumps only).

## How to test

Re-run CI; the `shellhub` package build step compiles the agent without the toolchain error.